### PR TITLE
Modify <img> element to support `alt` attribute

### DIFF
--- a/src/Doconano/Documents.fs
+++ b/src/Doconano/Documents.fs
@@ -154,7 +154,7 @@ module Documents =
         lists + e
     | Span(t, attr) -> "<span" + Attributes.showAll attr + ">" + t + "</span>"
     | Div(d, attr)  -> "<div" + Attributes.showAll attr + ">" + docToHtml d + "</div>"
-    | Img(t, path, attr) -> "<img src=\"" + path + "\"" + Attributes.showAll attr + ">" + t + "</img>"
+    | Img(t, path, attr) -> "<img src=\"" + path + "\" alt=\"" + t + "\"" + Attributes.showAll attr + ">"
     | RawHtml(html) -> html
     | AggregDoc(docs) -> docs |> List.map docToHtml |> List.rev |> Utility.concat
     | PhysicalNewLine -> "\n"

--- a/test/Doconano.Test/DocumentsTest.fs
+++ b/test/Doconano.Test/DocumentsTest.fs
@@ -111,7 +111,7 @@ module DocumentsTest =
             case (Documents.ul [Documents.rawHtml "unordered list", [Documents.p "p"]], "<ul>\n<li>unordered list<p>p</p></li>\n</ul>")
             case (Documents.span "span", "<span>span</span>")
             case (Documents.div <| Documents.p "p", "<div><p>p</p></div>")
-            case (Documents.img "img" "/path/to/ref", "<img src=\"/path/to/ref\">img</img>")
+            case (Documents.img "img" "/path/to/ref", "<img src=\"/path/to/ref\" alt=\"img\">")
             case (Documents.rawHtml "<a href='/hoge'>hoge</a>", "<a href='/hoge'>hoge</a>")
             run parameterizedTest
         }


### PR DESCRIPTION
* Make 1st argument of Img(string, string, ElementAttribute) as `alt`
  attribute in spite of the content of <img> (it was wrong...)